### PR TITLE
[as2_platform_mavlink] Use as2::Node::getParameter to read node parameters

### DIFF
--- a/src/mavlink_platform.cpp
+++ b/src/mavlink_platform.cpp
@@ -53,21 +53,15 @@ MavlinkPlatform::MavlinkPlatform(const rclcpp::NodeOptions & options)
 
   base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
   odom_frame_id_ = as2::tf::generateTfName(this, "odom");
-
-  this->declare_parameter<float>("max_thrust");
-  max_thrust_ = this->get_parameter("max_thrust").as_double();
-
-  this->declare_parameter<float>("min_thrust");
-  min_thrust_ = this->get_parameter("min_thrust").as_double();
-
-  this->declare_parameter<bool>("external_odom");
-  external_odom_ = this->get_parameter("external_odom").as_bool();
+  max_thrust_ = this->getParameter<double>("max_thrust");
+  min_thrust_ = this->getParameter<double>("min_thrust");
+  external_odom_ = this->getParameter<bool>("external_odom");
 
   RCLCPP_INFO(this->get_logger(), "Max thrust: %f", max_thrust_);
   RCLCPP_INFO(this->get_logger(), "Min thrust: %f", min_thrust_);
   RCLCPP_INFO(
     this->get_logger(), "Simulation mode: %s",
-    this->get_parameter("use_sim_time").as_bool() ? "true" : "false");
+    this->getParameter<bool>("use_sim_time") ? "true" : "false");
   RCLCPP_INFO(this->get_logger(), "External odometry mode: %s", external_odom_ ? "true" : "false");
 
   // declare mavlink_ subscribers


### PR DESCRIPTION
Reads the node parameters through `as2::Node::getParameter` instead of pairing `declare_parameter` with `get_parameter`.

`as2::Node::getParameter` declares the parameter when it is not declared yet and logs the value it read, so this package reports its configuration at startup like the rest of the stack.

4 reads migrated. One file, +4/-10.
Depends on https://github.com/aerostack2/aerostack2/pull/986, which adds `as2::Node::getParameter`.