### PR TITLE
[as2_platform_mavlink] Read the canonical robot frames from as2::Node

### DIFF
--- a/src/mavlink_platform.cpp
+++ b/src/mavlink_platform.cpp
@@ -51,8 +51,8 @@ MavlinkPlatform::MavlinkPlatform(const rclcpp::NodeOptions & options)
 {
   configureSensors();
 
-  base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
-  odom_frame_id_ = as2::tf::generateTfName(this, "odom");
+  base_link_frame_id_ = this->getBaseFrameId();
+  odom_frame_id_ = this->getOdomFrameId();
   max_thrust_ = this->getParameter<double>("max_thrust");
   min_thrust_ = this->getParameter<double>("min_thrust");
   external_odom_ = this->getParameter<bool>("external_odom");


### PR DESCRIPTION
Asks `as2::Node` for the canonical robot frames instead of building them from string literals.

The four frames every robot has — the global one, the map, the local odometry frame and the body — are declared once by `as2::Node` and namespaced there, so naming a frame in the robot config reaches every node. This package built its own, which no parameter could change.

Depends on https://github.com/aerostack2/aerostack2/pull/989, which has to be merged first.