### PR TITLE
[as2_platform_mavlink] Declare the frames of the platform commands

### DIFF
--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -6,7 +6,7 @@
 #
 # unset             = 0 = 0b0000
 # hover             = 1 = 0b0001
-# acro              = 2 = 0b0010
+# body_rates        = 2 = 0b0010
 # attitude          = 3 = 0b0011
 # speed             = 4 = 0b0100
 # speed_in_a_plane  = 5 = 0b0101
@@ -34,14 +34,14 @@
 #   SPEED + YAW ANGLE + ENU
 #   SPEED + YAW SPEED + ENU
 #   ATTITUDE + YAW ANGLE + ENU
-#   ACRO + YAW SPEED + FLU
+#   BODY_RATES + YAW SPEED + FLU
 #
 #-----------------------------------------------------------------
 
 available_modes:
   - 0b00000000 # UNSET
   # - 0b00010000 # HOVER
-  - 0b00100100 # ACRO (p,q,r, Thrust)
+  - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
   # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
   # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME

--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------
 # A complete control mode is an 8 bits flag 
-# (4bits control mode + 2 yaw mode bits + 2 reference frame bits)
+# (4bits control mode + 2 yaw mode bits + 2 reserved bits)
 #
 # ------------- mode codification (4 bits) ----------------------
 #
@@ -18,23 +18,19 @@
 # angle             = 0 = 0b00
 # speed             = 1 = 0b01
 # 
-# frame codification
-# 
-# local_frame_flu   = 0 = 0b00
-# global_frame_enu  = 1 = 0b01
-# global_frame_lla  = 2 = 0b10
+# Bits [1:0] are reserved and ignored
 # 
 #-----------------------------------------------------------------
 
 #------------------- pixhawk control modes -----------------------
 #
 #   UNSET
-#   POSITION + YAW ANGLE + ENU
-#   POSITION + YAW SPEED + ENU
-#   SPEED + YAW ANGLE + ENU
-#   SPEED + YAW SPEED + ENU
-#   ATTITUDE + YAW ANGLE + ENU
-#   BODY_RATES + YAW SPEED + FLU
+#   POSITION + YAW ANGLE
+#   POSITION + YAW SPEED
+#   SPEED + YAW ANGLE
+#   SPEED + YAW SPEED
+#   ATTITUDE + YAW ANGLE
+#   BODY_RATES + YAW SPEED
 #
 #-----------------------------------------------------------------
 
@@ -42,17 +38,13 @@ available_modes:
   - 0b00000000 # UNSET
   # - 0b00010000 # HOVER
   - 0b00100100 # BODY_RATES (p,q,r, Thrust)
-  - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
-  # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
-  # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01000001 # SPEED with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01000100 # SPEED with yaw SPEED in the LOCAL_FLU_FRAME
-  - 0b01000101 # SPEED with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01010001 # SPEED_IN_A_PLANE with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED in the LOCAL_FLU_FRAME
-  # - 0b01010101 # SPEED_IN_A_PLANE with yaw SPEED in the GLOBAL_ENU_FRAME
-  - 0b01100001 # POSITION with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01100101 # POSITION with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01110001 # TRAJECTORY with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01110101 # TRAJECTORY with yaw SPEED in the GLOBAL_ENU_FRAME
+  - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
+  # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
+  # - 0b01000000 # SPEED with yaw ANGLE
+  - 0b01000100 # SPEED with yaw SPEED
+  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE
+  # - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED
+  - 0b01100000 # POSITION with yaw ANGLE
+  # - 0b01100100 # POSITION with yaw SPEED
+  # - 0b01110000 # TRAJECTORY with yaw ANGLE
+  # - 0b01110100 # TRAJECTORY with yaw SPEED

--- a/include/as2_platform_mavlink/mavlink_platform.hpp
+++ b/include/as2_platform_mavlink/mavlink_platform.hpp
@@ -216,7 +216,7 @@ private:
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr mavlink_pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr mavlink_twist_setpoint_pub_;
-  rclcpp::Publisher<mavros_msgs::msg::AttitudeTarget>::SharedPtr mavlink_acro_setpoint_pub_;
+  rclcpp::Publisher<mavros_msgs::msg::AttitudeTarget>::SharedPtr mavlink_body_rates_setpoint_pub_;
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr mavlink_vision_pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr mavlink_vision_speed_pub_;

--- a/include/as2_platform_mavlink/mavlink_platform.hpp
+++ b/include/as2_platform_mavlink/mavlink_platform.hpp
@@ -174,7 +174,6 @@ private:
   std::unique_ptr<as2::sensors::Sensor<nav_msgs::msg::Odometry>> odometry_raw_estimation_ptr_;
   std::unique_ptr<as2::sensors::GPS> gps_sensor_ptr_;
 
-  std::shared_ptr<as2::tf::TfHandler> tf_handler_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr external_odometry_sub_;
   /**
    * @brief Forward an external velocity estimate to the autopilot, as visual

--- a/src/mavlink_platform.cpp
+++ b/src/mavlink_platform.cpp
@@ -109,7 +109,7 @@ MavlinkPlatform::MavlinkPlatform(const rclcpp::NodeOptions & options)
 
   mavlink_pose_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>(
     "mavros/setpoint_position/local", 10);
-  mavlink_acro_setpoint_pub_ = this->create_publisher<mavros_msgs::msg::AttitudeTarget>(
+  mavlink_body_rates_setpoint_pub_ = this->create_publisher<mavros_msgs::msg::AttitudeTarget>(
     "mavros/setpoint_raw/attitude", 10);
   mavlink_twist_setpoint_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
     "mavros/setpoint_velocity/cmd_vel", 10);
@@ -175,8 +175,8 @@ bool MavlinkPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode
     case as2_msgs::msg::ControlMode::ATTITUDE: {
         RCLCPP_INFO(this->get_logger(), "ATTITUDE_MODE ENABLED");
       } break;
-    case as2_msgs::msg::ControlMode::ACRO: {
-        RCLCPP_INFO(this->get_logger(), "ACRO_MODE ENABLED");
+    case as2_msgs::msg::ControlMode::BODY_RATES: {
+        RCLCPP_INFO(this->get_logger(), "BODY_RATES_MODE ENABLED");
       } break;
     default: {
         RCLCPP_WARN(this->get_logger(), "CONTROL MODE %d NOT SUPPORTED", msg.control_mode);
@@ -231,7 +231,7 @@ bool MavlinkPlatform::ownSendCommand()
           this->command_pose_msg_.pose.orientation,
           thrust_normalized);
       } break;
-    case as2_msgs::msg::ControlMode::ACRO: {
+    case as2_msgs::msg::ControlMode::BODY_RATES: {
         mavlink_publishRatesSetpoint(
           this->command_twist_msg_.twist.angular.x,
           this->command_twist_msg_.twist.angular.y,
@@ -309,7 +309,7 @@ void MavlinkPlatform::mavlink_publishRatesSetpoint(
   msg.body_rate.y = dpitch;
   msg.body_rate.z = dyaw;
   msg.thrust = dthrust;
-  mavlink_acro_setpoint_pub_->publish(msg);
+  mavlink_body_rates_setpoint_pub_->publish(msg);
 }
 
 void MavlinkPlatform::mavlink_publishAttitudeSetpoint(
@@ -323,7 +323,7 @@ void MavlinkPlatform::mavlink_publishAttitudeSetpoint(
     mavros_msgs::msg::AttitudeTarget::IGNORE_YAW_RATE;
   msg.orientation = q;
   msg.thrust = thrust;
-  mavlink_acro_setpoint_pub_->publish(msg);
+  mavlink_body_rates_setpoint_pub_->publish(msg);
 }
 
 

--- a/src/mavlink_platform.cpp
+++ b/src/mavlink_platform.cpp
@@ -87,7 +87,6 @@ MavlinkPlatform::MavlinkPlatform(const rclcpp::NodeOptions & options)
     std::make_shared<as2::SynchronousServiceClient<mavros_msgs::srv::SetMode>>(
     "mavros/set_mode", this);
 
-  tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   if (external_odom_) {
     mavlink_vision_pose_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>(
@@ -165,6 +164,10 @@ bool MavlinkPlatform::ownSetOffboardControl(bool offboard)
 
 bool MavlinkPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg)
 {
+  // The MAVLink setpoints are built from the local reference frame of the vehicle
+  setCommandPoseFrameId(odom_frame_id_);
+  setCommandTwistFrameId(odom_frame_id_);
+
   switch (msg.control_mode) {
     case as2_msgs::msg::ControlMode::POSITION: {
         RCLCPP_INFO(this->get_logger(), "POSITION_MODE ENABLED");
@@ -265,11 +268,11 @@ void MavlinkPlatform::externalOdomCb(const geometry_msgs::msg::TwistStamped::Sha
       odom_frame_id_, base_link_frame_id_);
 
     mavlink_vision_speed_msg_.header.stamp = twist_msg.header.stamp;
-    mavlink_vision_speed_msg_.header.frame_id = twist_msg.header.frame_id;   // BODY_FRAME_FLU
+    mavlink_vision_speed_msg_.header.frame_id = twist_msg.header.frame_id;   // body frame
     mavlink_vision_speed_msg_.twist = twist_msg.twist;
 
     mavlink_vision_pose_msg_.header.stamp = pose_msg.header.stamp;
-    mavlink_vision_pose_msg_.header.frame_id = pose_msg.header.frame_id;   // LOCAL_FRAME_FLU
+    mavlink_vision_pose_msg_.header.frame_id = pose_msg.header.frame_id;   // local reference frame
     mavlink_vision_pose_msg_.pose = pose_msg.pose;
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(this->get_logger(), "Could not get transform: %s", ex.what());

--- a/tests/pixhawk_control_mode/main.py
+++ b/tests/pixhawk_control_mode/main.py
@@ -105,7 +105,6 @@ class Test(Node):
         req = SetPlatformControlMode.Request()
         req.control_mode.control_mode = mode
         req.control_mode.yaw_mode = yaw_mode
-        # req.control_mode.reference_frame = 0  # Deprecated
 
         future = self.set_mode_srv.call_async(req)
         rclpy.spin_until_future_complete(self, future, timeout_sec=10)

--- a/tests/pixhawk_platform_test.cpp
+++ b/tests/pixhawk_platform_test.cpp
@@ -172,7 +172,6 @@ int platform_test()
   as2_msgs::msg::ControlMode control_mode;
   control_mode.control_mode = as2_msgs::msg::ControlMode::SPEED;
   control_mode.yaw_mode = as2_msgs::msg::ControlMode::YAW_SPEED;
-  control_mode.reference_frame = as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME;
   if (!test_node->setControlMode(control_mode, false)) {
     return -1;
   }


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | — |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Not flown, builds and tests only |

---

## Description of contribution in a few bullet points

* **The platform declares the frames of its commands.** It names, per control
  mode, the TF frame it wants each command in, and the base class converts them
  before handing them over. The reference frame of the control mode is gone, so
  the platform no longer reads it, and the modes that only differed by frame
  collapse into one.

* **`ACRO` is renamed to `BODY_RATES`.** It was named after a flight mode of one
  autopilot, while every other mode is named after the quantity it commands.

Depends on #5, which has to be merged first, and on aerostack2/aerostack2#990.
